### PR TITLE
fixed issue with tokenized message log messages being missing

### DIFF
--- a/Source/OUURuntime/Private/Logging/MessageLogBlueprintLibrary.cpp
+++ b/Source/OUURuntime/Private/Logging/MessageLogBlueprintLibrary.cpp
@@ -22,12 +22,13 @@ void UMessageLogBlueprintLibrary::AddTokenizedMessageLogMessage(FName MessageLog
 	{
 		MessageTokens.Add(FMessageLogToken::CreateTextMessageLogToken(FText::FromString("<empty message>")));
 	}
-	TSharedRef<FTokenizedMessage> Message = FMessageLog(MessageLogName).Message(
-		StaticCast<EMessageSeverity::Type>(Severity));
+
+	TSharedRef<FTokenizedMessage> Message = FTokenizedMessage::Create(StaticCast<EMessageSeverity::Type>(Severity));
 	for (auto& Token : MessageTokens)
 	{
 		Message->AddToken(Token.CreateNativeMessageToken());
 	}
+	FMessageLog(MessageLogName).AddMessage(Message);
 }
 
 void UMessageLogBlueprintLibrary::OpenMessageLog(FName MessageLogName, EMessageLogSeverity InMinSeverity,


### PR DESCRIPTION
FMessageLog::Message() sends the message right away so previously the message would look like "PIE: Error: " and then the tokens would be added after, but never sent to the log.
With the fix the tokens are added to the created message and then added to the log to look like "PIE: Error: MyToken".