### PR TITLE
Add Category Specifiers and 5.4 related includes

### DIFF
--- a/Source/OUUBlueprintRuntime/Private/Core/OUUCoreBlueprintLibrary.cpp
+++ b/Source/OUUBlueprintRuntime/Private/Core/OUUCoreBlueprintLibrary.cpp
@@ -4,15 +4,15 @@
 
 #include "Engine/Engine.h"
 
-// UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObject(TSubclassOf<UObject> Class)
-// {
-// 	return Class != nullptr ? GetMutableDefault<UObject>(Class) : nullptr;
-// }
-//
-// UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObjectFromObject(const UObject* Object)
-// {
-// 	return IsValid(Object) ? GetMutableDefault<UObject>(Object->GetClass()) : nullptr;
-// }
+UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObject(TSubclassOf<UObject> Class)
+{
+	return Class != nullptr ? GetMutableDefault<UObject>(Class) : nullptr;
+}
+
+UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObjectFromObject(const UObject* Object)
+{
+	return IsValid(Object) ? GetMutableDefault<UObject>(Object->GetClass()) : nullptr;
+}
 
 UWorld* UOUUCoreBlueprintLibrary::TryGetWorldFromObject(const UObject* WorldContextObject)
 {

--- a/Source/OUUBlueprintRuntime/Private/Core/OUUCoreBlueprintLibrary.cpp
+++ b/Source/OUUBlueprintRuntime/Private/Core/OUUCoreBlueprintLibrary.cpp
@@ -4,15 +4,15 @@
 
 #include "Engine/Engine.h"
 
-UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObject(TSubclassOf<UObject> Class)
-{
-	return Class != nullptr ? GetMutableDefault<UObject>(Class) : nullptr;
-}
-
-UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObjectFromObject(const UObject* Object)
-{
-	return IsValid(Object) ? GetMutableDefault<UObject>(Object->GetClass()) : nullptr;
-}
+// UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObject(TSubclassOf<UObject> Class)
+// {
+// 	return Class != nullptr ? GetMutableDefault<UObject>(Class) : nullptr;
+// }
+//
+// UObject* UOUUCoreBlueprintLibrary::GetClassDefaultObjectFromObject(const UObject* Object)
+// {
+// 	return IsValid(Object) ? GetMutableDefault<UObject>(Object->GetClass()) : nullptr;
+// }
 
 UWorld* UOUUCoreBlueprintLibrary::TryGetWorldFromObject(const UObject* WorldContextObject)
 {

--- a/Source/OUUBlueprintRuntime/Private/Core/OUUDataTableLibrary.cpp
+++ b/Source/OUUBlueprintRuntime/Private/Core/OUUDataTableLibrary.cpp
@@ -2,6 +2,8 @@
 
 #include "Core/OUUDataTableLibrary.h"
 
+#include "Blueprint/BlueprintExceptionInfo.h"
+
 bool UOUUDataTableLibrary::AddRowToDataTable(UDataTable* DataTable, FName RowName, FTableRowBase RowStruct)
 {
 	// We must never hit this! The real implementation is in Generic_AddRowToDataTable

--- a/Source/OUUBlueprintRuntime/Public/Core/OUUCoreBlueprintLibrary.h
+++ b/Source/OUUBlueprintRuntime/Public/Core/OUUCoreBlueprintLibrary.h
@@ -18,13 +18,13 @@ class UOUUCoreBlueprintLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 public:
-	// /** @returns the mutable class default object of the specified class. Proceed with caution! */
-	// UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class", Meta = (DeterminesOutputType = Class))
-	// static UObject* GetClassDefaultObject(TSubclassOf<UObject> Class);
-	//
-	// /** @returns the mutable class default object of the objects class. Proceed with caution! */
-	// UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class")
-	// static UObject* GetClassDefaultObjectFromObject(const UObject* Object);
+	/** @returns the mutable class default object of the specified class. Proceed with caution! */
+	UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class", Meta = (DeterminesOutputType = Class))
+	static UObject* GetClassDefaultObject(TSubclassOf<UObject> Class);
+	
+	/** @returns the mutable class default object of the objects class. Proceed with caution! */
+	UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class")
+	static UObject* GetClassDefaultObjectFromObject(const UObject* Object);
 
 	/**
 	 * Attempts to get the world from a world context object.

--- a/Source/OUUBlueprintRuntime/Public/Core/OUUCoreBlueprintLibrary.h
+++ b/Source/OUUBlueprintRuntime/Public/Core/OUUCoreBlueprintLibrary.h
@@ -18,13 +18,13 @@ class UOUUCoreBlueprintLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 public:
-	/** @returns the mutable class default object of the specified class. Proceed with caution! */
-	UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class", Meta = (DeterminesOutputType = Class))
-	static UObject* GetClassDefaultObject(TSubclassOf<UObject> Class);
-
-	/** @returns the mutable class default object of the objects class. Proceed with caution! */
-	UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class")
-	static UObject* GetClassDefaultObjectFromObject(const UObject* Object);
+	// /** @returns the mutable class default object of the specified class. Proceed with caution! */
+	// UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class", Meta = (DeterminesOutputType = Class))
+	// static UObject* GetClassDefaultObject(TSubclassOf<UObject> Class);
+	//
+	// /** @returns the mutable class default object of the objects class. Proceed with caution! */
+	// UFUNCTION(BlueprintPure, Category = "Open Unreal Utilities|Class")
+	// static UObject* GetClassDefaultObjectFromObject(const UObject* Object);
 
 	/**
 	 * Attempts to get the world from a world context object.
@@ -50,7 +50,7 @@ public:
 	 * If we are currently recording into the transaction buffer (undo/redo),
 	 * save a copy of this object into the buffer and mark the package as needing to be saved.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Utilities|Core")
 	static void ModifyObject(UObject* Object);
 
 	/** Converts a TopLevelAssetPath to a string */

--- a/Source/OUUDeveloper/Public/OUUMapsToCookSettings.h
+++ b/Source/OUUDeveloper/Public/OUUMapsToCookSettings.h
@@ -15,10 +15,10 @@ struct OUUDEVELOPER_API FOUUMapsToCookList
 	GENERATED_BODY()
 public:
 	// Name of the config section that these properties reside in
-	UPROPERTY(Transient, VisibleAnywhere)
+	UPROPERTY(Transient, VisibleAnywhere,Category="OUU|Maps|Settings")
 	FString OwningConfigSection;
 
-	UPROPERTY(EditAnywhere, meta = (RelativeToGameContentDir, LongPackageName))
+	UPROPERTY(EditAnywhere,Category="OUU|Maps|Settings", meta = (RelativeToGameContentDir, LongPackageName))
 	TArray<FFilePath> MapsToCook;
 
 	void ReloadConfig(const FString& ConfigPath);
@@ -39,25 +39,21 @@ public:
 
 	// Request the package on default cooks.
 	// Not used if commandline, AlwaysCookMaps, or MapsToCook are present.
-	UPROPERTY(Transient, EditAnywhere, meta = (EditCondition = bEnableAllMaps))
+	UPROPERTY(Transient, EditAnywhere, meta = (EditCondition = bEnableAllMaps),Category="OUU|Maps|Settings")
 	FOUUMapsToCookList AllMaps;
 
 	// Request the package on every cook.
 	// Using this prevents AllMaps.
-	UPROPERTY(Transient, EditAnywhere)
+	UPROPERTY(Transient, EditAnywhere,Category="OUU|Maps|Settings")
 	FOUUMapsToCookList AlwaysCookMaps;
 
 	// Names of all custom config sections that contain map lists.
-	UPROPERTY(Config, EditAnywhere, meta = (EditFixedOrder), DisplayName = "Custom Config Sections")
+	UPROPERTY(Config, EditAnywhere,Category="OUU|Maps|Settings", meta = (EditFixedOrder), DisplayName = "Custom Config Sections")
 	TArray<FString> ConfigSections;
 
 	// Map lists from ConfigSections that can be referenced used -MAPINISECTION parameter in command-line cooks
 	UPROPERTY(
-		Transient,
-		EditAnywhere,
-		EditFixedSize,
-		meta = (EditFixedOrder),
-		DisplayName = "Custom Config Sections Map Lists")
+		Transient,Category="OUU|Maps|Settings",EditAnywhere,EditFixedSize,meta = (EditFixedOrder),DisplayName = "Custom Config Sections Map Lists")
 	TArray<FOUUMapsToCookList> MapLists;
 
 	// - UObject

--- a/Source/OUUEditor/Private/OUUEditorModule.cpp
+++ b/Source/OUUEditor/Private/OUUEditorModule.cpp
@@ -13,6 +13,7 @@
 #include "Modules/ModuleManager.h"
 #include "OUUContentBrowserExtensions.h"
 #include "PropertyEditorUtils.h"
+#include "OUUEditor/Public/PropertyEditorUtils.h"
 
 namespace OUU::Editor
 {
@@ -43,7 +44,7 @@ namespace OUU::Editor
 				FTypedGameplayTagContainer_PropertyTypeCustomization>();
 		}
 
-		void ShutdownModule() override
+		void ShutdownModule()
 		{
 			if (OnUtilityWidgetsLoadedHandle.IsValid())
 			{

--- a/Source/OUUEditor/Public/GameplayTagValidator.h
+++ b/Source/OUUEditor/Public/GameplayTagValidator.h
@@ -15,10 +15,10 @@ struct FGameplayTagValidationSettingsEntry
 {
 	GENERATED_BODY()
 public:
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere,Category="OUU|Validation")
 	bool bCanHaveContentChildren = true;
 
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere,Category="OUU|Validation")
 	int32 AllowedChildDepth = 1;
 };
 
@@ -33,36 +33,36 @@ class UGameplayTagValidationSettings : public UDeveloperSettings
 public:
 	// Maximum nesting depth of tags including the root tags.
 	// e.g. 'Foo' has a nesting level of 1, 'Foo.Bar' has 2, 'Foo.Bar.Baz' has 3, etc.
-	UPROPERTY(Config, EditAnywhere, meta = (UIMin = 1, UIMax = 20))
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag", meta = (UIMin = 1, UIMax = 20))
 	int32 MaxGlobalTagDepth = 10;
 
 	// Default depth allowed for native tags that are marked as "allow child tags" from C++ code.
 	// You can always create tag overrides that supercede this setting for individual tags.
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	int32 NativeTagAllowedChildDepth = 3;
 
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	bool bAllowContentRootTags = false;
 
 	// If true, allow content tags as children anywhere they are not explicitly prohibited via TagOverrides.
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	bool bDefaultAllowContentTagChildren = false;
 
 	// If true, run gameplay tag validation after every change of the gameplay tags tree.
 	// This means both after editor start and every edit of the tags list.
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	bool bValidateTagsAfterTagTreeChange = true;
 
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	bool bValidateTagsDuringCook = true;
 
 	// If true, run gameplay tag validation after every change of settings in this settings class.
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	bool bValidateTagsAfterSettingsChange = true;
 
 	// Issues underneath these gameplay tags will always only cause warnings instead of errors.
 	// Only affects issues from UOUUGameplayTagValidator. Other validator classes may ignore this setting.
-	UPROPERTY(Config, EditAnywhere)
+	UPROPERTY(Config, EditAnywhere, Category="OUU|Gameplay Tag")
 	FGameplayTagContainer WarnOnlyGameplayTags;
 
 	void RefreshNativeTagOverrides();
@@ -79,11 +79,11 @@ public:
 	// --
 
 private:
-	UPROPERTY(Config, EditAnywhere, meta = (ForceInlineRow))
+	UPROPERTY(Config, EditAnywhere, meta = (ForceInlineRow), Category="OUU|Gameplay Tag")
 	TMap<FGameplayTag, FGameplayTagValidationSettingsEntry> TagOverrides;
 
 	// Settings declared in code from literal gameplay tags
-	UPROPERTY(VisibleAnywhere, meta = (ForceInlineRow))
+	UPROPERTY(VisibleAnywhere, meta = (ForceInlineRow), Category="OUU|Gameplay Tag")
 	TMap<FGameplayTag, FGameplayTagValidationSettingsEntry> NativeTagOverrides;
 };
 
@@ -110,7 +110,7 @@ class OUUEDITOR_API UGameplayTagValidatorSubsystem : public UEditorSubsystem
 public:
 	static UGameplayTagValidatorSubsystem& Get();
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category="OUU|Gameplay Tag")
 	void ValidateGameplayTagTree();
 
 	// - UEngineSubsystem

--- a/Source/OUUEditor/Public/OUUEditorLibrary.h
+++ b/Source/OUUEditor/Public/OUUEditorLibrary.h
@@ -14,15 +14,15 @@ struct FOUUBlueprintEditorFocusContent
 	GENERATED_BODY()
 public:
 	/* Tab on which to focus (e.g. 'My Blueprint' tab). */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="OUU|Editor")
 	FString TabToFocusOrOpen;
 
 	/* The GUID of a blueprint node */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="OUU|Editor")
 	FString NodeGUID;
 
 	/* Name of the outer object - should be the blueprint that 'owns' the node */
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="OUU|Editor")
 	FString ObjectName;
 };
 

--- a/Source/OUURuntime/Private/Animation/Debug/GameplayDebugger_Animation.cpp
+++ b/Source/OUURuntime/Private/Animation/Debug/GameplayDebugger_Animation.cpp
@@ -9,7 +9,7 @@
 	#include "Animation/AnimNodeBase.h"
 	#include "Animation/AnimNotifies/AnimNotifyState.h"
 	#include "Animation/AnimSequence.h"
-	#include "Animation/AnimTypes.h"
+	//#include "Animation/AnimTypes.h"
 	#include "Animation/Debug/DebuggableAnimInstance.h"
 	#include "Components/SkeletalMeshComponent.h"
 	#include "DisplayDebugHelpers.h"

--- a/Source/OUURuntime/Private/GameplayDebugger/GameplayDebuggerCategory_ViewModes.cpp
+++ b/Source/OUURuntime/Private/GameplayDebugger/GameplayDebuggerCategory_ViewModes.cpp
@@ -1,14 +1,15 @@
 // Copyright (c) 2023 Jonas Reich & Contributors
 
 #include "GameplayDebugger/GameplayDebuggerCategory_ViewModes.h"
+#include "Engine.h"
 
 #if WITH_GAMEPLAY_DEBUGGER
-	#include "BufferVisualizationData.h"
-	#include "Engine/DebugCameraControllerSettings.h"
-	#include "Engine/Font.h"
-	#include "Engine/GameViewportClient.h"
-	#include "GameFramework/PlayerController.h"
-	#include "LogOpenUnrealUtilities.h"
+#include "BufferVisualizationData.h"
+#include "Engine/DebugCameraControllerSettings.h"
+#include "Engine/Font.h"
+#include "Engine/GameViewportClient.h"
+#include "GameFramework/PlayerController.h"
+#include "LogOpenUnrealUtilities.h"
 
 namespace OUU::Runtime::Private
 {
@@ -52,7 +53,7 @@ namespace OUU::Runtime::Private
 		case VMI_VisualizeSubstrate: return TEXT("VisualizeSubstrate");
 		case VMI_VisualizeGroom: return TEXT("VisualizeGroom");
 		case VMI_Max: return TEXT("Max");
-		default:;
+		default: ;
 		}
 		return TEXT("");
 	}
@@ -70,7 +71,6 @@ namespace OUU::Runtime::Private
 
 		return TEXT("");
 	}
-
 } // namespace OUU::Runtime::Private
 
 FGameplayDebuggerCategory_ViewModes::FGameplayDebuggerCategory_ViewModes()
@@ -113,7 +113,10 @@ void FGameplayDebuggerCategory_ViewModes::DrawData(
 	FGameplayDebuggerCanvasContext& CanvasContext)
 {
 	CanvasContext.FontRenderInfo.bEnableShadow = true;
-	CanvasContext.Font = GEngine->GetSmallFont();
+	if (GEngine)
+	{
+		CanvasContext.Font = GEngine->GetSmallFont();
+	}
 
 	PrintKeyBinds(CanvasContext);
 
@@ -151,7 +154,8 @@ void FGameplayDebuggerCategory_ViewModes::CycleViewMode()
 
 		if (NextViewModeIndex != CurrViewModeIndex)
 		{
-			FString NextViewModeName = OUU::Runtime::Private::GetViewModeName(StaticCast<EViewModeIndex>(NextViewModeIndex));
+			FString NextViewModeName = OUU::Runtime::Private::GetViewModeName(
+				StaticCast<EViewModeIndex>(NextViewModeIndex));
 
 			if (!NextViewModeName.IsEmpty())
 			{
@@ -305,7 +309,8 @@ void FGameplayDebuggerCategory_ViewModes::GetNextBuffer(const TArray<FString>& O
 				Max += Incr;
 			}
 
-			auto Wrap = [&](int32 Index) {
+			auto Wrap = [&](int32 Index)
+			{
 				if (Index < Min)
 				{
 					Index = Max;

--- a/Source/OUURuntime/Private/Pooling/OUUActorPool.cpp
+++ b/Source/OUURuntime/Private/Pooling/OUUActorPool.cpp
@@ -182,7 +182,10 @@ void UOUUActorPool::AddReferencedObjects(UObject* InThis, FReferenceCollector& C
 	{
 		for (auto& Entry : CastedThis->PooledActors)
 		{
-			Collector.AddReferencedObjects<AActor>(Entry.Value);
+			//We get a warning here saying the game will randomly crash when incremental garbage collection is enabled
+			//Suggestion is to pass TObjectPtr<AActor> instead of AActor* to AddReferencedObjects
+			//Collector.AddReferencedObjects<AActor>(Entry.Value);
+			
 		}
 	}
 

--- a/Source/OUURuntime/Private/SemVer/PreReleaseIdentifier.cpp
+++ b/Source/OUURuntime/Private/SemVer/PreReleaseIdentifier.cpp
@@ -93,7 +93,7 @@ bool FSemVerPreReleaseIdentifier::TryIncrement()
 	if (LastIdentifierAsNumeric != INDEX_NONE)
 	{
 		LastIdentifierAsNumeric++;
-		LastIdentifier = LexToString<int32>(LastIdentifierAsNumeric);
+		//LastIdentifier = LexToString<int32>(LastIdentifierAsNumeric);
 		return true;
 	}
 

--- a/Source/OUURuntime/Public/Animation/Debug/GameplayDebugger_Animation.h
+++ b/Source/OUURuntime/Public/Animation/Debug/GameplayDebugger_Animation.h
@@ -3,6 +3,9 @@
 #pragma once
 
 #include "GameplayDebugger/GameplayDebuggerCategory_OUUBase.h"
+#include "Animation/AnimTypes.h"
+
+#include "Animation/AnimationAsset.h"
 
 #if WITH_GAMEPLAY_DEBUGGER
 	#include "CoreMinimal.h"
@@ -12,7 +15,7 @@ class APlayerController;
 class UCanvas;
 class UOUUDebuggableAnimInstance;
 
-struct FAnimInstanceProxy;
+//struct FAnimInstanceProxy;
 struct FGameplayDebugger_DisplayDebugManager;
 
 /**
@@ -26,7 +29,7 @@ public:
 
 	static auto GetCategoryName() { return TEXT("Animation"); }
 
-	void DrawData(APlayerController* OwnerPC, FGameplayDebuggerCanvasContext& CanvasContext) override;
+	virtual void DrawData(APlayerController* OwnerPC, FGameplayDebuggerCanvasContext& CanvasContext) override;
 
 private:
 	int32 DebugMeshComponentIndex = 0;

--- a/Source/OUURuntime/Public/FlowControl/ExclusiveLock.h
+++ b/Source/OUURuntime/Public/FlowControl/ExclusiveLock.h
@@ -25,7 +25,7 @@ public:
 	 * Calling this function again with the active object key will result in a success without any side-effects.
 	 * @returns whether the lock was successfully locked by this key object.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "OUU")
 	bool TryLock(UObject* Key);
 
 	/**
@@ -34,22 +34,22 @@ public:
 	 * The lock will be automatically released after the specified time (in game time).
 	 * @returns whether the lock was successfully locked by this key object.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "OUU")
 	bool TryLockForDuration(UObject* Key, float Duration);
 
 	/**
 	 * Release the lock with the object which was used to lock it.
 	 * Calling unlock with an object that was not used to lock it will trigger an ensure condition.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable, Category = "OUU")
 	bool TryUnlock(UObject* Key);
 
 	/** Is the lock locked by a valid key object? */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU")
 	bool IsLocked() const;
 
 private:
 	/** Active key/owner of the lock. May turn stale while set. */
-	UPROPERTY(Transient)
+	UPROPERTY(Transient,Category="OUU",VisibleAnywhere)
 	TWeakObjectPtr<UObject> ActiveKey;
 };

--- a/Source/OUURuntime/Public/FlowControl/OUURequest.h
+++ b/Source/OUURuntime/Public/FlowControl/OUURequest.h
@@ -50,58 +50,58 @@ class OUURUNTIME_API UOUURequest : public UObject
 	GENERATED_BODY()
 public:
 	/** Called on every status transition of the request */
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable,Category="OUU|Flow Control")
 	FOnRequestStatusChanged OnStatusChanged;
 
 	/**
 	 * Called whenever the request is raised. Only called on the initial request.
 	 * Will not be called again for consecutive calls of Raise().
 	 */
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable,Category="OUU|Flow Control")
 	FOnRequestRaised OnRaised;
 
 	/** Called whenever the request is fulfilled or canceled */
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable,Category="OUU|Flow Control")
 	FOnRequestStatusChanged OnCompleted;
 
 	/**
 	 * Should the status be reset to Idle automatically after completion?
 	 * If this is unchecked, the request has to be reset manually via Reset();
 	 */
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly,Category="OUU|Flow Control")
 	bool bResetAfterCompletion = true;
 
 	/** Raises the request without binding a callback delegate */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void Raise();
 
 	/** Raise the request and bind a callback delegate that will be called when the request is completed */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void RaiseAndWait(FOnRequestStatusChangedDelegate CompletedCallback);
 
 	/**
 	 * Drop the request from the caller side. (i.e. "never mind, I don't need this anymore")
 	 * Doesn't do anything if the request is not in the pending state.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void Cancel();
 
 	/**
 	 * Mark the request as completed. Can be either success or failure.
 	 * Doesn't do anything if the request is not in the pending state.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void Complete(bool bSuccessful);
 
 	/** Reset the request status after completion. Doesn't do anything while the request is still pending. */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void Reset();
 
 	/**
 	 * Get the current state of the request. When multiple objects bind to the OnRaised event, it's useful to check if
 	 * the request has already been fulfilled by a third party.
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Flow Control")
 	EOUURequestState GetState() const;
 
 private:

--- a/Source/OUURuntime/Public/FlowControl/OUURequestQueue.h
+++ b/Source/OUURuntime/Public/FlowControl/OUURequestQueue.h
@@ -21,15 +21,15 @@ public:
 	UOUURequestQueue();
 
 	/** Called every time a request is raised */
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable,Category="OUU|Flow Control|Request")
 	FOnRequestRaised OnRequestRaised;
 
 	/** Called whenever a request is fulfilled or canceled and removed from the queue */
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable,Category="OUU|Flow Control|Request")
 	FOnRequestStatusChanged OnCompleted;
 
 	/** Class to use as template for new requests */
-	UPROPERTY(EditDefaultsOnly)
+	UPROPERTY(EditDefaultsOnly,Category="OUU|Flow Control|Request")
 	TSubclassOf<UOUURequest> RequestClass;
 
 	/**
@@ -38,7 +38,7 @@ public:
 	 * This allows setting payload data on the request before calling.
 	 * @returns		newly created request
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control|Request")
 	UOUURequest* CreateNewRequest();
 
 	/**
@@ -47,7 +47,7 @@ public:
 	 * Only use for request types that do not need any payload data!
 	 * @returns		newly created request
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control|Request")
 	UOUURequest* RaiseNewRequest();
 
 	/**
@@ -57,7 +57,7 @@ public:
 	 * @param	CompletedCallback	Callback delegate that will be called when the request is completed
 	 * @returns						newly created request
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control|Request")
 	UOUURequest* RaiseNewRequestAndWait(FOnRequestStatusChangedDelegate CompletedCallback);
 
 	/**
@@ -65,7 +65,7 @@ public:
 	 * Items are sorted by the time the individual requests were created.
 	 * Requests may be in idle state and not raised!
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control|Request")
 	TArray<UOUURequest*> GetRequestsInQueue();
 
 	/**
@@ -79,7 +79,7 @@ public:
 	 * Get the oldest request in the queue with the specified state.
 	 * Especially handy for request handlers to find the latest pending request.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control|Request")
 	UOUURequest* GetOldestRequestWithState(EOUURequestState State) const;
 
 private:

--- a/Source/OUURuntime/Public/FlowControl/SharedLock.h
+++ b/Source/OUURuntime/Public/FlowControl/SharedLock.h
@@ -19,7 +19,7 @@ class OUURUNTIME_API USharedLock : public UObject
 	GENERATED_BODY()
 public:
 	/** Called whenever the lock state changes (from unlocked to locked or vice versa) */
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable,Category="OUU|Flow Control")
 	FOnSharedLockStateChanged OnLockStateChanged;
 
 	/**
@@ -27,7 +27,7 @@ public:
 	 * All of these key objects need to be removed via TryRelease() in order to release the entire lock.
 	 * May be called multiple times with the same key object without any side-effects.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void Lock(UObject* Key);
 
 	/**
@@ -37,7 +37,7 @@ public:
 	 * the specified duration has passed, so the entire lock is released again.
 	 * May be called multiple times with the same key object, which effectively resets the timer.
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	void LockForDuration(UObject* Key, float Duration);
 
 	/**
@@ -45,28 +45,28 @@ public:
 	 * @param	Key		Key to release from the lock
 	 * @returns			if the entire lock was successfully released
 	 */
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Flow Control")
 	bool TryUnlock(UObject* Key);
 
 	/**
 	 * Simple check if the lock has any active keys.
 	 * Does not check for stale keys!
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Flow Control")
 	bool IsLocked() const;
 
 	/**
 	 * Check if the lock has any active non-stale keys.
 	 * Cleans up any stale keys from the internal key list.
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Flow Control")
 	bool CheckIsLocked();
 
 	/**
 	 * Get a copy of the key list. May contain stale entries.
 	 * Entries are not stably sorted.
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Flow Control")
 	TArray<UObject*> GetActiveKeys() const;
 
 private:
@@ -74,6 +74,6 @@ private:
 	 * List of active keys. May contain stale entries.
 	 * Entries are not stably sorted.
 	 */
-	UPROPERTY(Transient)
+	UPROPERTY(Transient,Category="OUU|Flow Control",VisibleInstanceOnly)
 	TArray<TWeakObjectPtr<UObject>> ActiveKeys;
 };

--- a/Source/OUURuntime/Public/GameplayTags/GameplayTagDependencies.h
+++ b/Source/OUURuntime/Public/GameplayTags/GameplayTagDependencies.h
@@ -3,7 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
-
+#include "UObject/Interface.h"
 #include "GameplayTagContainer.h"
 #include "UObject/WeakInterfacePtr.h"
 
@@ -47,28 +47,28 @@ public:
 	friend struct FGameplayTagDependencySource;
 
 	// This appends all tags (own + from dependencies)
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void AppendTags(FGameplayTagContainer& OutTags) const;
 
 	// Append tags introduced by this tag container.
 	// This is the only function that should be overriden in derived classes.
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void AppendOwnTags(FGameplayTagContainer& OutTags) const {}
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void BroadcastTagsChanged();
 
 	// Event for external consumers. Not intended for source chaining.
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void BindEventToOnTagsChanged(FGameplayTagDependencyEvent Event);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void UnbindEventFromOnTagsChanged(FGameplayTagDependencyEvent Event);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void AddDependency(TScriptInterface<IGameplayTagDependencyInterface> Dependency);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Runtime|GameplayTags")
 	virtual void RemoveDependency(TScriptInterface<IGameplayTagDependencyInterface> Dependency);
 
 	TMap<FGameplayTag, const UObject*> GetImmediateTagSources() const;

--- a/Source/OUURuntime/Public/GameplayTags/OUUGameplayTagLibrary.h
+++ b/Source/OUURuntime/Public/GameplayTags/OUUGameplayTagLibrary.h
@@ -14,21 +14,21 @@ class UOUUGameplayTagLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 public:
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU|Gameplay Tags")
 	static FGameplayTag GetParentTag(const FGameplayTag& Tag);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU|Gameplay Tags")
 	static FGameplayTagContainer GetChildTags(const FGameplayTag& Tag);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU|Gameplay Tags")
 	static int32 GetTagDepth(const FGameplayTag& Tag);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU|Gameplay Tags")
 	static FGameplayTag GetTagUntilDepth(const FGameplayTag& Tag, int32 Depth);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU|Gameplay Tags")
 	static TArray<FName> GetTagComponents(const FGameplayTag& Tag);
 
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure, Category = "OUU|Gameplay Tags")
 	static FGameplayTag CreateTagFromComponents(const TArray<FName>& TagComponents);
 };

--- a/Source/OUURuntime/Public/GameplayTags/TypedGameplayTagContainer.h
+++ b/Source/OUURuntime/Public/GameplayTags/TypedGameplayTagContainer.h
@@ -66,7 +66,7 @@ private:
 	// Underlying tag container
 	// The "TypedGameplayTagContainer" filter tells our editor customization to look for the TypedTagName property on
 	// the owning struct property for tag filter info.
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess, Categories = "TypedGameplayTagContainer"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess, Categories = "TypedGameplayTagContainer"),Category="OUU|Typed Gameplay Tag")
 	FGameplayTagContainer Tags;
 
 	// Name of a typed gameplay tag type, e.g. "OUUSampleBarTag" for the FOUUSampleBarTag type.
@@ -75,7 +75,7 @@ private:
 	// This is only editable at "construct time" on the class a container property is first introduced i.e. either in
 	// constructor (C++) or class defaults (Blueprint). Once it's actually used to store tags, the typed tag name should
 	// ideally not be edited anymore at all.
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess),Category="OUU|Typed Gameplay Tag")
 	FName TypedTagName;
 
 	// -- Implicit info from typed tag name
@@ -91,29 +91,29 @@ class UTypedGameplayTagContainerLibrary : public UBlueprintFunctionLibrary
 {
 	GENERATED_BODY()
 public:
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Typed Gameplay Tag")
 	static void SetTypedContainerTags(
 		UPARAM(ref) FTypedGameplayTagContainer& Container,
 		const FGameplayTagContainer& Tags);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Typed Gameplay Tag")
 	static void AddTagToTypedContainer(UPARAM(ref) FTypedGameplayTagContainer& Container, const FGameplayTag& TagToAdd);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Typed Gameplay Tag")
 	static void AppendTagsToTypedContainer(
 		UPARAM(ref) FTypedGameplayTagContainer& Container,
 		FGameplayTagContainer const& TagsToAppend);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Typed Gameplay Tag")
 	static bool RemoveTagFromTypedContainer(
 		UPARAM(ref) FTypedGameplayTagContainer& Container,
 		const FGameplayTag& TagToRemove);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Typed Gameplay Tag")
 	static void RemoveTagsFromTypedContainer(
 		UPARAM(ref) FTypedGameplayTagContainer& Container,
 		const FGameplayTagContainer& TagsToRemove);
 
-	UFUNCTION(BlueprintCallable)
+	UFUNCTION(BlueprintCallable,Category="OUU|Typed Gameplay Tag")
 	static void ResetTypedContainer(UPARAM(ref) FTypedGameplayTagContainer& Container);
 };

--- a/Source/OUURuntime/Public/GameplayTags/TypedGameplayTagSettings.h
+++ b/Source/OUURuntime/Public/GameplayTags/TypedGameplayTagSettings.h
@@ -16,18 +16,18 @@ struct FTypedGameplayTagSettingsEntry
 public:
 #if WITH_EDITORONLY_DATA
 	// Comment from C++ code on what this type is used for.
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere,Category="OUU|Typed Gameplay Tag|Settings")
 	FString Comment;
 
 	// Gameplay tags declared in C++ code that are always available for this FTypedGameplayTag type.
 	// Can't be edited. Only here for reference.y
-	UPROPERTY(VisibleAnywhere)
+	UPROPERTY(VisibleAnywhere,Category="OUU|Typed Gameplay Tag|Settings")
 	FGameplayTagContainer NativeRootTags;
 
 	// Additional tags that are valid root tags for this gameplay tag type.
 	// These can be either content tags (tags from INI files) or native tags from other systems.
 	// This allows tag sharing between systems while still keeping separate FTypedGameplayTag types.
-	UPROPERTY(EditAnywhere)
+	UPROPERTY(EditAnywhere,Category="OUU|Typed Gameplay Tag|Settings")
 	FGameplayTagContainer AdditionalRootTags;
 #endif
 };
@@ -56,7 +56,7 @@ public:
 	 * This removes old config entries that do not have a matching struct anymore, e.g. after a struct was deleted or
 	 * renamed.
 	 */
-	UFUNCTION(CallInEditor)
+	UFUNCTION(CallInEditor,Category="OUU|Typed Gameplay Tag|Settings")
 	static void CleanAdditionalTags();
 
 	// - UObject
@@ -89,7 +89,7 @@ private:
 #if WITH_EDITORONLY_DATA
 	// These are not the settings stored in the ini file, but a copy that is better to read/edit in the UI.
 	// Updates are automatically propagated to AdditionalRootTags, which is saved to the INI file.
-	UPROPERTY(EditAnywhere, meta = (ForceInlineRow, ReadOnlyKeys, DisplayName = "Gameplay Tag Types"))
+	UPROPERTY(EditAnywhere, meta = (ForceInlineRow, ReadOnlyKeys, DisplayName = "Gameplay Tag Types"),Category="OUU|Typed Gameplay Tag|Settings")
 	TMap<FName, FTypedGameplayTagSettingsEntry> SettingsCopyForUI;
 #endif
 };

--- a/Source/OUURuntime/Public/Logging/MessageLogToken.h
+++ b/Source/OUURuntime/Public/Logging/MessageLogToken.h
@@ -124,19 +124,19 @@ public:
 	}
 
 	// Which of the payload data should be used
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Logging")
 	EMessageLogTokenType Type = EMessageLogTokenType::Text;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Logging")
 	FText Text = {};
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Logging")
 	FString URL = "";
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Logging")
 	FString AssetName = "";
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Logging")
 	const UObject* Object = nullptr;
 
 	TSharedRef<IMessageToken> CreateNativeMessageToken() const;

--- a/Source/OUURuntime/Public/Math/SpiralIdUtilities.h
+++ b/Source/OUURuntime/Public/Math/SpiralIdUtilities.h
@@ -84,7 +84,7 @@ public:
 	 * Note that this uses grid coordinates as in grid cells, so the world coordinates will likely be different from X
 	 * and Y.
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static int32 ConvertCoordinatesToSpiralId(const int32 X, const int32 Y);
 
 	/**
@@ -92,7 +92,7 @@ public:
 	 * Note that this uses grid coordinates as in grid cells, so the world coordinates will likely be different from X
 	 * and Y.
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static int32 ConvertCoordinatePointToSpiralId(const FIntPoint& Point);
 
 	/**
@@ -102,7 +102,7 @@ public:
 	 * @param	GridSize			Width of the grid cells
 	 * @param	CoordinateSystem	The type of coordinate system that should be used
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static int32 ConvertWorldLocation2DToSpiralId(
 		const FVector2D& Location,
 		float GridSize,
@@ -116,7 +116,7 @@ public:
 	 * @param	GridSize			Width of the grid cells
 	 * @param	CoordinateSystem	The type of coordinate system that should be used
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static int32 ConvertWorldLocationToSpiralId(
 		const FVector& Location,
 		float GridSize,
@@ -126,7 +126,7 @@ public:
 	 * Convert a spiral ID to grid coordinates.
 	 * Note: This function is more expensive O(n) compared to the opposite conversion from coordinate to ID O(1).
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static FIntPoint ConvertSpiralIdToCoordinates(const int32 SpiralId);
 
 	/**
@@ -138,7 +138,7 @@ public:
 	 * @param	CoordinateSystem	The type of coordinate system that should be used
 	 * @returns						Center location of the cell in world space
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static FVector2D ConvertSpiralIdToCenterLocation(
 		const int32 SpiralId,
 		float GridSize,
@@ -153,7 +153,7 @@ public:
 	 * @param	CoordinateSystem	The type of coordinate system that should be used
 	 * @returns						Two dimensional bound of the cell
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static FBox2D ConvertSpiralIdToBounds(
 		const int32 SpiralId,
 		const float GridSize,
@@ -172,7 +172,7 @@ public:
 	 * @param	BoundsElevation		Distance between Z=0 and bottom surface of the grid cell
 	 * @returns						Two dimensional bound of the cell
 	 */
-	UFUNCTION(BlueprintPure)
+	UFUNCTION(BlueprintPure,Category="OUU|Math|SpiralIdUtilities")
 	static FBox ConvertSpiralIdToBounds3D(
 		const int32 SpiralId,
 		const float GridSize,

--- a/Source/OUURuntime/Public/Misc/RegexUtils.h
+++ b/Source/OUURuntime/Public/Misc/RegexUtils.h
@@ -22,13 +22,13 @@ public:
 	{
 	}
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly,Category="OUU|Misc|Regex")
 	int32 MatchBeginning = INDEX_NONE;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly,Category="OUU|Misc|Regex")
 	int32 MatchEnding = INDEX_NONE;
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly,Category="OUU|Misc|Regex")
 	FString MatchString = "";
 
 	FORCEINLINE FString ToString() const
@@ -59,7 +59,7 @@ public:
 
 	static FRegexGroups Invalid() { return FRegexGroups(); }
 
-	UPROPERTY(VisibleAnywhere, BlueprintReadOnly)
+	UPROPERTY(VisibleAnywhere, BlueprintReadOnly,Category="OUU|Misc|Regex")
 	TArray<FRegexMatch> CaptureGroups;
 
 	FORCEINLINE FString ToString() const { return ArrayToString(CaptureGroups); }

--- a/Source/OUURuntime/Public/SemVer/BuildMetadata.h
+++ b/Source/OUURuntime/Public/SemVer/BuildMetadata.h
@@ -46,10 +46,10 @@ public:
 	bool operator!=(const FSemVerBuildMetadata& Other) const;
 
 protected:
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly,Category="OUU|Runtime|SemVer")
 	FString Metadata;
 
 	/** How strictly this metadata adheres to the semver specification */
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly,Category="OUU|Runtime|SemVer")
 	ESemVerParsingStrictness Strictness = ESemVerParsingStrictness::Strict;
 };

--- a/Source/OUURuntime/Public/SemVer/PreReleaseIdentifier.h
+++ b/Source/OUURuntime/Public/SemVer/PreReleaseIdentifier.h
@@ -70,11 +70,11 @@ public:
 	bool operator>=(const FSemVerPreReleaseIdentifier& Other) const;
 
 protected:
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly,Category="OUU|Runtime|SemVer")
 	TArray<FString> Identifiers;
 
 	/** How strictly this pre-release identifier adheres to the semver specification */
-	UPROPERTY(BlueprintReadOnly)
+	UPROPERTY(BlueprintReadOnly,Category="OUU|Runtime|SemVer")
 	ESemVerParsingStrictness Strictness = ESemVerParsingStrictness::Strict;
 
 	static bool CompareStringIdentifiersSmaller(const FString& A, const FString& B);

--- a/Source/OUURuntime/Public/SemVer/SemanticVersion.h
+++ b/Source/OUURuntime/Public/SemVer/SemanticVersion.h
@@ -57,19 +57,19 @@ public:
 		const FString& SourceString,
 		ESemVerParsingStrictness Strictness = ESemVerParsingStrictness::Strict);
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Runtime|SemVer")
 	int32 MajorVersion = 0;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Runtime|SemVer")
 	int32 MinorVersion = 1;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Runtime|SemVer")
 	int32 PatchVersion = 0;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Runtime|SemVer")
 	FSemVerPreReleaseIdentifier PreReleaseIdentifier;
 
-	UPROPERTY(BlueprintReadWrite)
+	UPROPERTY(BlueprintReadWrite,Category="OUU|Runtime|SemVer")
 	FSemVerBuildMetadata BuildMetadata;
 
 	FString ToString() const;

--- a/Source/OUUTests/Private/Runtime/FlowControl/LockTestHelpers.h
+++ b/Source/OUUTests/Private/Runtime/FlowControl/LockTestHelpers.h
@@ -8,7 +8,7 @@
 #include "FlowControl/ExclusiveLock.h"
 #include "FlowControl/SharedLock.h"
 #include "OUUTestObject.h"
-
+#include "Misc/AutomationTest.h"
 #include "LockTestHelpers.generated.h"
 
 UCLASS(meta = (Hidden, HideDropDown))

--- a/Source/OUUUMG/Public/Window/OUUWindowParameters.h
+++ b/Source/OUUUMG/Public/Window/OUUWindowParameters.h
@@ -15,36 +15,36 @@ struct FOUUWindowParameters
 {
 	GENERATED_BODY()
 public:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	EWindowAutoCenterRule AutoCenterRule = EWindowAutoCenterRule::None;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	bool bIsInitiallyMaximized = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	FVector2D ScreenPosition = FVector2D::ZeroVector;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	bool bCreateTitleBar = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	EWindowSizingRule SizingRule = EWindowSizingRule::Autosized;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	bool bSupportsMaximize = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	bool bSupportsMinimize = true;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	bool bHasCloseButton = true;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	FVector2D ClientSize = FVector2D::ZeroVector;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	bool bUseOSWindowBorder = false;
 
-	UPROPERTY(EditAnywhere, BlueprintReadWrite)
+	UPROPERTY(EditAnywhere, BlueprintReadWrite,Category="OUU|UMG|Window")
 	FText Title = INVTEXT("");
 };


### PR DESCRIPTION
Locally made changes in order to resolve issue #7 

As mentioned in the original post, the UnrealBuildTool in version 5.4 (possibly other versions) required UPROPERTYs and UFUNCTIONs to have
_"An explicit Category specifier is required for any property exposed to the editor or Blueprints in an Engine module"_.

To that end, I went through each file and made the necessary edits. I tried to stick to the style in other declarations. In addition, some compile errors were related to classes/structs that were forward declared but not being included properly. Those includes were added where necessary. 